### PR TITLE
Fix `echo` in WinRT header generation

### DIFF
--- a/nuget.cmake
+++ b/nuget.cmake
@@ -92,14 +92,7 @@ function(nuget_add_winrt target_name)
         ${winrt_version_test}
     COMMAND_ERROR_IS_FATAL ANY
     )
-    execute_process(
-    COMMAND
-        echo
-        ${winrt_sdk_version}
-    OUTPUT_FILE
-        ${sdk_version_test}
-    COMMAND_ERROR_IS_FATAL ANY
-    )
+    file(WRITE ${sdk_version_test} ${winrt_sdk_version})
     execute_process(
     COMMAND
         ${CMAKE_COMMAND} -E compare_files ${winrt_version_key} ${winrt_version_test}


### PR DESCRIPTION
Since `echo` is shell command, not executable binary, CMake won't see it. This will cause "command not found" error.

There are two ways to migitate this.

First way (currently used) is to use `file(WRITE ...)`. Since original command just writes output of `echo` to file, this should be enough.
```cmake
    file(WRITE ${sdk_version_test} ${winrt_sdk_version})
```

Second way is to use `${CMAKE_COMMAND} -E echo ...` instead of `echo`. Full code will look like this:
```cmake
    execute_process(
    COMMAND
        ${CMAKE_COMMAND} -E echo
        ${winrt_sdk_version}
    OUTPUT_FILE
        ${sdk_version_test}
    COMMAND_ERROR_IS_FATAL ANY
    )
```

If for any reason second way is preferable, let me know, and I'll change my PR to it.
